### PR TITLE
fixed Pager Duty to PagerDuty (no space)

### DIFF
--- a/pages/doc/2017_32.x_release_notes.md
+++ b/pages/doc/2017_32.x_release_notes.md
@@ -44,7 +44,7 @@ Try it out and let us know your feedback!
 Managing who gets notified when alerts fire gets increasingly complex as more users adopt Wavefront and the number of alerts increases. Alert targets makes it easier to manage notifications by providing a shared notification "target" that can be used by many alerts. There are three types of alert targets:
 
 - Email: An email distribution list
-- Pager Duty: Send to a PagerDuty Service
+- PagerDuty: Send to a PagerDuty Service
 - Webhook: Call a Webhook URL
 
 Alert targets also allow you to customize the content of the alert that is sent using Mustache templates. You can now control the content of the alert sent to email and PagerDuty, in addition to the customization that could already be done with Webhooks. Within the template you have access to many of the values associated with the alert, including the value of the condition that triggered the alert.


### PR DESCRIPTION
Fixed extra space to be consistent with doc and pagerduty's website.