### PR TITLE
Add HTTP support documentation for Pushlistener

### DIFF
--- a/pages/doc/proxies_configuring.md
+++ b/pages/doc/proxies_configuring.md
@@ -280,7 +280,7 @@ Default: <code>&lt;wf_config_path&gt;/logsIngestion.yaml</code>.</td>
 </tr>
 <tr>
 <td>pushListenerPorts</td>
-<td>TCP ports to listen on for incoming data. Default: 2878.</td>
+<td>Port to listen on for incoming data.  A single port definition can accept both HTTP and TCP data.  For HTTP data, make a POST to this proxy port with an empty header, and the line terminated data format (https://docs.wavefront.com/wavefront_data_format.html). Default: 2878.</td>
 <td>Comma-separated list of available port numbers. Can be a single port.
 <div>Ex: 2878</div>
 <div>Ex: 2878,2879,2880</div></td>


### PR DESCRIPTION
The pushlistenerport accepts HTTP data, in the format listed in the change.  Both TCP and HTTP data are accepted.