### PR TITLE
proxy config: ephemeral is in wrong order

### DIFF
--- a/pages/doc/proxies_configuring.md
+++ b/pages/doc/proxies_configuring.md
@@ -106,13 +106,13 @@ Ex: 45</td>
 <td>3.14</td>
 </tr>
 <tr>
-<tr>
 <td>ephemeral</td>
 <td>Whether to automatically clean up old and orphaned proxy instances from the Wavefront Proxies page. We recommend enabling ephemeral mode if you're running the proxy in a container that may be frequently spun down and recreated. Default: false.</td>
 <td>Boolean<br/>
 Ex: true </td>
 <td>3.14</td>
 </tr>
+<tr>
 <td>fileBeatPort</td>
 <td>TCP port to listen on for Filebeat data. Default: 5044.</td>
 <td>A port number.<br/>

--- a/pages/doc/proxies_configuring.md
+++ b/pages/doc/proxies_configuring.md
@@ -91,13 +91,6 @@ Ex: 8760</td>
 <td>4.1</td>
 </tr>
 <tr>
-<td>ephemeral</td>
-<td>Whether to automatically clean up old and orphaned proxy instances from the Wavefront Proxies page. We recommend enabling ephemeral mode if you're running the proxy in a container that may be frequently spun down and recreated. Default: false.</td>
-<td>Boolean<br/>
-Ex: true </td>
-<td>3.14</td>
-</tr>
-<tr>
 <td>deltaCounterPorts</td>
 <td>Port on which to listen only for <a href="delta_counters.html">delta counter data</a>. Other data format are rejected at this port. If you specify a delta counter port, it can accept both HTTP and TCP data. For HTTP data, make a POST to this proxy port with an empty header, and the line-terminated data. Use this property in conjunction with deltaCounterAggregationInterval to limit the number of points per second for delta counters.  Default: 50000.</td>
 <td>Comma-separated list of available port numbers. Can be a single port.<br/>
@@ -113,6 +106,13 @@ Ex: 45</td>
 <td>3.14</td>
 </tr>
 <tr>
+<tr>
+<td>ephemeral</td>
+<td>Whether to automatically clean up old and orphaned proxy instances from the Wavefront Proxies page. We recommend enabling ephemeral mode if you're running the proxy in a container that may be frequently spun down and recreated. Default: false.</td>
+<td>Boolean<br/>
+Ex: true </td>
+<td>3.14</td>
+</tr>
 <td>fileBeatPort</td>
 <td>TCP port to listen on for Filebeat data. Default: 5044.</td>
 <td>A port number.<br/>


### PR DESCRIPTION
Fixed proxy config options

`ephemeral` is now in the proper place alphabetically
