### PR TITLE
Add proxy configurations

### DIFF
--- a/pages/doc/proxies_configuring.md
+++ b/pages/doc/proxies_configuring.md
@@ -129,7 +129,7 @@ Ex: 45</td>
 <tr>
 <td>ephemeral</td>
 <td>Whether to automatically clean up old and orphaned proxy instances from the Wavefront Proxies page. We recommend enabling ephemeral mode if you're running the proxy in a container that may be frequently spun down and recreated. <br/>Default: true.
-{% include note.html content="Starting from version 6.0, the value defaults to true (it defaulted to false from 3.14 to 6.0)." %}</td>
+{% include note.html content="Starting with version 6.0, the value defaults to true (it defaulted to false from 3.14 to 6.0)." %}</td>
 <td>Boolean<br/>
 Ex: false </td>
 <td>3.14</td>
@@ -222,7 +222,7 @@ Properties specific to histogram distributions, listed in a <a href="#histogram-
 <tr>
 <td>idFile</td>
 <td>Location of the PID file for the wavefront-proxy process. <br/>Default: &lt;dshell&gt;/.id</td>
-<td>Valid path on the local file system. This configuration is ignored when ephemeral=true.</td>
+<td>Valid path on the local file system. This option is ignored when ephemeral=true.</td>
 <td>&nbsp;</td>
 </tr>
 <tr>
@@ -459,7 +459,7 @@ Ex: 2978,2979</td>
 <tr>
 <td>retryThreads</td>
 <td>Number of threads retrying failed transmissions. If no value is specified, defaults to the number of processor cores available to the host or 4, whichever is greater. Every retry thread uses a separate buffer file (capped at 2GB) to persist queued data points, so the number of threads controls the maximum amount of space that the proxy can use to buffer points locally.
-{% include warning.html content="This configuration was deprecated in version 6.0 because we redesigned and improved the storage engine to resolve the problem of spooling data to disk." %}
+{% include warning.html content="This configuration was deprecated in version 6.0 because we redesigned the storage engine to improve spooling data to disk.." %}
 </td>
 <td>Positive integer.
 <div>Ex: 4 </div>  </td>

--- a/pages/doc/proxies_configuring.md
+++ b/pages/doc/proxies_configuring.md
@@ -95,7 +95,7 @@ Ex: RawBlockedPoints</td>
 <td>Location of buffer files for saving failed transmissions for retry.</td>
 <td>Valid path on the local file system.<br/>
 Ex: &lt;wf_spool_path&gt;/buffer</td>
-<td>3.20</td>
+<td>The start</td>
 </tr>
 <tr>
 <td>customSourceTags</td>
@@ -128,9 +128,10 @@ Ex: 45</td>
 </tr>
 <tr>
 <td>ephemeral</td>
-<td>Whether to automatically clean up old and orphaned proxy instances from the Wavefront Proxies page. We recommend enabling ephemeral mode if you're running the proxy in a container that may be frequently spun down and recreated. <br/>Default: false.</td>
+<td>Whether to automatically clean up old and orphaned proxy instances from the Wavefront Proxies page. We recommend enabling ephemeral mode if you're running the proxy in a container that may be frequently spun down and recreated. <br/>Default: true.
+{% include note.html content="Starting from version 6.0, the value defaults to true (it defaulted to false from 3.14 to 6.0)." %}</td>
 <td>Boolean<br/>
-Ex: true </td>
+Ex: false </td>
 <td>3.14</td>
 </tr>
 <tr>
@@ -220,8 +221,8 @@ Properties specific to histogram distributions, listed in a <a href="#histogram-
 </tr>
 <tr>
 <td>idFile</td>
-<td>Location of the PID file for the wavefront-proxy process. <br/>Default: &lt;cfg_path&gt;/.wf_id.</td>
-<td>Valid path on the local file system.</td>
+<td>Location of the PID file for the wavefront-proxy process. <br/>Default: &lt;dshell&gt;/.id</td>
+<td>Valid path on the local file system. This configuration is ignored when ephemeral=true.</td>
 <td>&nbsp;</td>
 </tr>
 <tr>
@@ -304,7 +305,9 @@ Default: &lt;cfg_path&gt;/logsIngestion.yaml.</td>
 </tr>
 <tr>
 <td>pushBlockedSamples</td>
-<td>Number of blocked points to print to the log immediately following each summary line (every 10 flushes). If 0, print none. If you see a non-zero number of blocked points in the summary lines and want to debug what that data is, set this property to 5. <br/>Default: 0.</td>
+<td>Number of blocked points to print to the log immediately following each summary line (every 10 flushes). If 0, print none. If you see a non-zero number of blocked points in the summary lines and want to debug what that data is, set this property to 5. <br/>Default: 5
+{% include note.html content="Defaults to 5 since version 5.0. Before version 5.0 it defaulted to 0." %}
+</td>
 <td>0 or a positive integer.
 <div>Ex: 5 </div></td>
 <td>&nbsp;</td>
@@ -368,10 +371,12 @@ Default: &lt;cfg_path&gt;/logsIngestion.yaml.</td>
 </tr>
 <tr>
 <td>pushLogLevel</td>
-<td>Frequency to print status information on the data flow to the log. SUMMARY prints a line every 60 flushes, while DETAILED prints a line on each flush.</td>
+<td>Frequency to print status information on the data flow to the log. SUMMARY prints a line every 60 flushes, while DETAILED prints a line on each flush.
+{% include warning.html content="This configuration was deprecated in version 6.0. The level of logging is controlled through log4j2 configurations." %}
+</td>
 <td>None, SUMMARY, or DETAILED
 <div>Ex: SUMMARY </div></td>
-<td>&nbsp;</td>
+<td>Deprecated since 6.0.</td>
 </tr>
 <tr>
 <td>pushMemoryBufferLimit</td>
@@ -453,10 +458,12 @@ Ex: 2978,2979</td>
 <td>&nbsp;</td></tr>
 <tr>
 <td>retryThreads</td>
-<td>Number of threads retrying failed transmissions. If no value is specified, defaults to the number of processor cores available to the host or 4, whichever is greater. Every retry thread uses a separate buffer file (capped at 2GB) to persist queued data points, so the number of threads controls the maximum amount of space that the proxy can use to buffer points locally.</td>
+<td>Number of threads retrying failed transmissions. If no value is specified, defaults to the number of processor cores available to the host or 4, whichever is greater. Every retry thread uses a separate buffer file (capped at 2GB) to persist queued data points, so the number of threads controls the maximum amount of space that the proxy can use to buffer points locally.
+{% include warning.html content="This configuration was deprecated in version 6.0 because we redesigned and improved the storage engine to resolve the problem of spooling data to disk." %}
+</td>
 <td>Positive integer.
 <div>Ex: 4 </div>  </td>
-<td>&nbsp;</td>
+<td>Deprecated since 6.0.</td>
 </tr>
 <tr>
 <td>server</td>
@@ -466,7 +473,7 @@ Ex: 2978,2979</td>
 </tr>
 <tr>
 <td>soLingerTime</td>
-<td>Enable SO_LINGER with the specified linger time in seconds. Set this value to 0 when running in a high-availability configuration under a load balancer. <br/>Default: 0 (disabled). </td>
+<td>Enable SO_LINGER with the specified linger time in seconds. Set this value to 0 when running in a high-availability configuration under a load balancer. <br/>Default: -1 (disabled). </td>
 <td><div>0 or a positive integer.</div>
 Ex: 0 </td>
 <td>4.1</td>
@@ -492,6 +499,12 @@ Ex: 0 </td>
 <td>Comma-separated list of available port numbers. Can be a single port.
 <div>Ex: 4878 </div></td>
 <td>3.14</td>
+</tr>
+<tr>
+<td>rawLogsHttpBufferSize</td>
+<td>The maximum request size (in bytes) for incoming HTTP requests with tracing data. <br/>Default: 16MB</td>
+<td>Buffer size in bytes. <br/> Ex: 16777216 </td>
+<td>4.38</td>
 </tr>
 </tbody>
 </table>
@@ -573,6 +586,12 @@ Ex: 0 </td>
 <td>Comma separated list of custom tag keys to include as metric tags for the derived RED (Request, Error, Duration) metrics. Applicable to Jaeger and Zipkin integration only.</td>
 <td>traceDerivedCustomTagKeys=tenant, env, location</td>
 <td>4.38 </td>
+</tr>
+<tr>
+<td>traceListenerHttpBufferSize</td>
+<td>The maximum request size (in bytes) for incoming HTTP requests with tracing data. <br/>Default: 16MB</td>
+<td>Buffer size in bytes. <br/> Ex: 16777216 </td>
+<td>4.37 </td>
 </tr>
 </tbody>
 </table>
@@ -819,6 +838,11 @@ Ex: 40</td>
 <td>pushRelayHistogramAggregatorAccumulatorSize</td>
 <td>Since 6.0. Max number of concurrent histogram to accumulations at the relay ports. The value is approximately the number of time series * 2 (use a higher multiplier if out-of-order points more than 1 bin apart are expected). Setting this value too high will cause excessive disk space usage, setting this value too low may cause severe performance issues. Only applicable if the pushRelayHistogramAggregator is set to true. <br/> Default: 32.</td>
 <td>Positive integer.</td>
+</tr>
+<tr>
+<td>histogramHttpBufferSize</td>
+<td>Since 4.40. The maximum request size (in bytes) for incoming HTTP requests on histogram ports.<br/> Default: 16MB.</td>
+<td>Buffer size in bytes. <br/> Ex: 16777216</td>
 </tr>
 </tbody>
 </table>

--- a/pages/doc/proxies_versions.md
+++ b/pages/doc/proxies_versions.md
@@ -20,7 +20,7 @@ This page gives an overview of important changes for the most recent Wavefront p
 - [Ability to export data that is queued at the proxy](proxies_installing.html#export-data-queued-at-the-proxy).
 - Deprecated configurations:
   - Deprecated `pushLogLevel` because the level of logging is now controlled through log4j2 configurations.
-  - Deprecated `retryThreads` because we redesigned and improved the storage engine to resolve the problem of spooling data to disk.
+  - Deprecated `retryThreads` because we redesigned the storage engine to improve spooling data to disk.
 
 ## Version 5.7
 

--- a/pages/doc/proxies_versions.md
+++ b/pages/doc/proxies_versions.md
@@ -18,6 +18,9 @@ This page gives an overview of important changes for the most recent Wavefront p
 - [Jaeger integration can now receive data via HTTP](proxies_configuring.html#traceJaegerHttpListenerPorts).
 - Log blocked points for [histograms and spans into separate log files](proxies_configuring.html#logging).
 - [Ability to export data that is queued at the proxy](proxies_installing.html#export-data-queued-at-the-proxy).
+- Deprecated configurations:
+  - Deprecated `pushLogLevel` because the level of logging is now controlled through log4j2 configurations.
+  - Deprecated `retryThreads` because we redesigned and improved the storage engine to resolve the problem of spooling data to disk.
 
 ## Version 5.7
 


### PR DESCRIPTION
Updated the following as per the feedback from Vassily.

`buffer: `this setting is available since the beginning of time, not 3.20
`ephemeral`: defaults to true starting with 6.0
`idFile`: defaults to ~/.dshell/id (has always been the case). ignored when ephemeral=true
`pushBlockedSamples`: defaults to 5 since 5.0
`pushLogLevel`: deprecated since 6.0, level of logging is controlled through log4j2 config.
`histogramHttpBufferSize`: Maximum allowed request size (in bytes) for incoming HTTP requests on histogram ports (Default: 16MB)
`traceListenerHttpBufferSize`: Maximum allowed request size (in bytes) for incoming HTTP requests with tracing data (Default: 16MB)
`rawLogsHttpBufferSize`: Maximum allowed request size (in bytes) for incoming HTTP requests with raw logs (Default: 16MB)
retryThreads: deprecated since 6.0
`soLingerTime`: default is -1 (disabled). 0 doesn’t mean disabled.