### PR TITLE
Minor CSS improvement

### DIFF
--- a/css/wavefront-doc-style.css
+++ b/css/wavefront-doc-style.css
@@ -1262,7 +1262,7 @@ a code {
 }
 
 code + a > code {
-    margin-left: -7px;
+    margin-left: 1px;
 }
 
 table th code {

--- a/pages/doc/proxies_versions.md
+++ b/pages/doc/proxies_versions.md
@@ -20,7 +20,7 @@ This page gives an overview of important changes for the most recent Wavefront p
 - [Jaeger integration can now receive data via HTTP](proxies_configuring.html#traceJaegerHttpListenerPorts).
 - Log blocked points for [histograms and spans into separate log files](proxies_configuring.html#logging).
 - [Ability to export data that is queued at the proxy](proxies_installing.html#export-data-queued-at-the-proxy).
-- Deprecated configurations:
+- Deprecated configuration options:
   - `retryThreads` configuration option is deprecated as it is no longer applicable to the new storage engine. 
   - `pushLogLevel` configuration option is deprecated as logging levels are configured through log4j2 configurations. 
 


### PR DESCRIPTION
- If we use text in code format and a link in code format in the same sentence, the link overlaps the text. This fixes the issue (-7 px > 1 px)
- Minor update to proxy 6.1 release notes.