### PR TITLE
Update info for global rules

### DIFF
--- a/pages/doc/proxies_preprocessor_rules.md
+++ b/pages/doc/proxies_preprocessor_rules.md
@@ -79,10 +79,10 @@ Wavefront uses Java-style regex pattern. For details see [the Java documentation
 ### Applying Rules to Multiple Ports
 
 A preprocessor rule typically specifies rules for a specific port. The example above specifies the rule for port 2878. Starting with proxy v7.x, you can:
-* Use the `global` keyword to specify rules for all ports. For example:
+* Use the `global` keyword to specify rules that should apply for all explicitly specified ports. Additionally, global rules must be specified at the bottom of the preprocessor rule file. For example:
 
 ```
-   # rules that apply to all ports
+   # rules that apply to all ports explicitly specified above. Global rules must be at the end of the file.
    'global':
 
      # Example no-op rule


### PR DESCRIPTION
Realized that the example provided in the Proxy GitHub is actually incorrect (just filed a PR to correct that). The way "global" rules work is that they apply to all explicitly specified ports in the preprocessor rule file. Additionally, the global rules must be at the end of the file (since it looks for all previously specified ports in the file and so, if the global rule was at the beginning, there would be no other rules above/previous to it). Hope that makes sense