### PR TITLE
CMD/CTRL clicking on a search result should open in a new tab

### DIFF
--- a/css/wavefront-doc-style.css
+++ b/css/wavefront-doc-style.css
@@ -1721,6 +1721,11 @@ div.sidebarTitle {
     background-color: transparent;
 }
 
+.nav li a.wf-suggestion-link p {
+    color: #52606d;
+    font-weight: 600;
+}
+
 .wf-docs-no-results {
     margin: 20px 20px;
     font-weight: 600;

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -113,13 +113,13 @@ function addSearchFunctionForInput(containerId, mobileContainerId, searchInputId
                     },
                     suggestion: function (suggestion) {
                         return '<div class="wf-docs-search-autocomplete-suggestion">' +
-                            '<a class="wf-suggestion-link" href="' + suggestion.url + '">' + suggestion._highlightResult.title.value + '</a>' +
-                            '<p>' + (suggestion.summary || '') + '</p>' +
+                            '<a class="wf-suggestion-link" href="' + suggestion.url + '">' + suggestion._highlightResult.title.value + 
+                            '<p>' + (suggestion.summary || '') + '</p>' + '</a>' +
                             '</div>';
                     }
                 }
             }).on('autocomplete:selected', function (event, suggestion, dataset) {
-            window.location.href = suggestion.url;
+            return false
         }).on('autocomplete:opened', function () {
             $body.addClass('wf-search-opened');
         }).on('autocomplete:closed', function () {

--- a/js/customscripts.js
+++ b/js/customscripts.js
@@ -118,8 +118,12 @@ function addSearchFunctionForInput(containerId, mobileContainerId, searchInputId
                             '</div>';
                     }
                 }
-            }).on('autocomplete:selected', function (event, suggestion, dataset) {
-            return false
+            }).on('autocomplete:selected', function (event, suggestion, dataset, context) {
+                if (context.selectionMethod == 'click') {
+                    return false;
+                }
+
+                window.location.assign(suggestion.url);
         }).on('autocomplete:opened', function () {
             $body.addClass('wf-search-opened');
         }).on('autocomplete:closed', function () {


### PR DESCRIPTION
The search results html has been restructured so that the anchor wraps all of the content. Users can now cmd/ctrl-click and a new tab will open for the search result. Pressing tab, enter, or clicking on a search result will still replace the current page.

See Algolia [docs](https://github.com/algolia/autocomplete/blob/45fa32d008620cf52bf4a90530be338543dfba7f/README.md#how-can-i-control-click-on-results-and-have-them-open-in-a-new-tab) 