### PR TITLE
Add the --incremental flag to the jekyll command in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ Wavefront public repositories into the official documentation)
 
 1. Run Jekyll with the following command:
    ```shell
-   $ bundle exec jekyll server
+   $ bundle exec jekyll server --incremental
    ```
 1. Go to url [http://localhost:4000/](http://localhost:4000/). The host and port are set in [_config.yml](_config.yml).


### PR DESCRIPTION
This isn't necessary, but I found that adding this flag sped up the server by quite a bit when I updated individual files. It seemed to regenerate every single file even if only one was changed initially, and this flag seems to cause it to only regenerate changed files.