### PR TITLE
Removed the note about alerting on ~alert

### DIFF
--- a/pages/doc/wavefront_internal_metrics.md
+++ b/pages/doc/wavefront_internal_metrics.md
@@ -18,9 +18,6 @@ You can:
 We collect the following sets of metrics.
 
 - `~alert*` -- a set of metrics that allows you to examine the effect of alerts on your service instance.
-
-   {% include note.html content=" Alerting on the `~alert*` set of metrics is not supported. Alerts in which you use the `~alert*` set of metrics will show **No Data** even when data flows. You can use these metrics only in charts and dashboards." %}
-
 - `~collector` -- metrics processed at the collector gateway to the service instance. Includes spans.
 - `~metric` -- total unique sources and metrics.  You can compute the rate of metric creation from each source.
 - `~proxy` -- metric rate received and sent from each Wavefront proxy, blocked and rejected metric rates, buffer metrics, and JVM stats of the proxy. Also includes counts of metrics affected by the proxy preprocessor. See [Monitor Wavefront Proxies](monitoring_proxies.html).

--- a/pages/doc/webhooks_alert_notification.md
+++ b/pages/doc/webhooks_alert_notification.md
@@ -345,5 +345,3 @@ ts(~alert.webhooks.*.*, name=<webhook_name>)
 ```
 
 If the response code of the webhook is anything other than 2xx, we create an event with the name `<webhook_id>.<webhook_name>.<response_code>`.
-
-{% include note.html content=" Alerting on the `~alert.webhooks.*` set of metrics is not supported. All alerts which use the `~alert*` set of  metrics will show **No Data** even when data flows. You can use these metrics only in charts and dashboards." %}


### PR DESCRIPTION
Removing the note, the team implemented some changes and the notes are no longer needed